### PR TITLE
Handling of multiple IMEI / vehicles

### DIFF
--- a/configuration.template.json
+++ b/configuration.template.json
@@ -15,7 +15,8 @@
     },
     "Logging":{
         "LogToFile": false,
-        "LogLevel": 50
+        "LogLevel": 20,
+        "Timezone": "Europe/Berlin"
     },
     "MQTT": {
         "Enabled" : true,

--- a/configuration.template.json
+++ b/configuration.template.json
@@ -1,8 +1,11 @@
 {
-    "IMEI" : "my_imei",
+    "IMEI_List": [
+        "my_imei-1",
+        "my_imei-2"
+    ],
 
     "TCPServer":{
-        "serverPORT" : 38955,
+        "BasePort" : 38955,
         "bridgeMode" : true,
         "silenceHOST" : "api.connectivity.silence.eco",
         "silencePORT" : 38955,

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -1,13 +1,31 @@
 import os
+import pytz
 import logging
 import logging.handlers
 from helpers.constants import LOGGER_NAME
+from datetime import datetime
 
 def setup_logger(configuration):
 
     logger = logging.getLogger(LOGGER_NAME)
     logger.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s - [%(module)s] - %(levelname)s - %(message)s')
+
+   # Define a custom time formatter that considers the given timezone
+    class TimezoneFormatter(logging.Formatter):
+        def __init__(self, fmt=None, datefmt=None, tz=None):
+            super().__init__(fmt, datefmt)
+            self.tz = tz
+
+        def formatTime(self, record, datefmt=None):
+            dt = datetime.fromtimestamp(record.created, self.tz)
+            formatted_time = dt.strftime('%Y-%m-%d %H:%M:%S.%f')
+            formatted_time = formatted_time[:-3]
+            timezone_abbr = dt.tzname()
+            return f"{formatted_time} {timezone_abbr}"
+
+    # Get the timezone object
+    timezone_obj = pytz.timezone(configuration["Timezone"])
+    formatter = TimezoneFormatter('%(asctime)s - [%(module)s] - %(levelname)s - %(message)s', tz=timezone_obj)
 
     # logging to file
     if (configuration["LogToFile"]):

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -1,20 +1,24 @@
+import os
 import logging
 import logging.handlers
 from helpers.constants import LOGGER_NAME
 
 def setup_logger(configuration):
-    
+
     logger = logging.getLogger(LOGGER_NAME)
     logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - [%(module)s] - %(levelname)s - %(message)s')
-   
+
     # logging to file
     if (configuration["LogToFile"]):
-        file_handler = logging.handlers.TimedRotatingFileHandler('logs/silence-server.log', when='midnight', interval=1, backupCount=10)
+        log_path = 'logs'
+        os.makedirs(log_path, exist_ok=True)
+        log_file_path = os.path.join(log_path, 'silence-server.log')
+        file_handler = logging.handlers.TimedRotatingFileHandler(log_file_path, when='midnight', interval=1, backupCount=10)
         file_handler.setLevel(configuration["LogLevel"])
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
-    
+
     # logging to console
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.DEBUG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 paho_mqtt==1.6.1
 Pypubsub==4.0.3
+pytz==2024.2

--- a/services/CommandService.py
+++ b/services/CommandService.py
@@ -13,15 +13,15 @@ log = logging.getLogger(LOGGER_NAME)
 
 class CommandService:
 
-    def __init__(self):
+    def __init__(self, configuration, IMEI):
         super().__init__()
-        log.debug("CommandService init")
-
+        log.debug(f"CommandService init ({IMEI})")
         self.command_queue = Queue()
         self._running = False
+        self.IMEI = IMEI
 
     def start(self):
-        
+
         try:
             # load message parsing configuration
             with open(os.path.join("helpers", "commands_definition.json")) as commands_definition:
@@ -30,7 +30,7 @@ class CommandService:
             # add default "RAW_COMMAND" command
             self.commands_definition[RAW_COMMAND_CODE] = {'timeout': 10, 'retry' : 1, 'command': ''}
 
-            log.debug(f"Subscribing to {TOPIC_COMMAND_RECEIVED}")
+            log.debug(f"Subscribing to {TOPIC_COMMAND_RECEIVED} ({self.IMEI})")
             pub.subscribe(self.command_received, TOPIC_COMMAND_RECEIVED)
 
             self._running = True
@@ -39,30 +39,30 @@ class CommandService:
             thread.daemon = True
             thread.start()
 
-            log.info(f"CommandService Started")
+            log.info(f"CommandService Started ({self.IMEI})")
 
         except Exception:
             log.exception("Exception in CommandService start")
             return
-    
+
     def stop(self):
         self._running = False
-        log.info(f"CommandService Stop")
+        log.info(f"CommandService Stopped ({self.IMEI})")
 
     def run(self):
         while self._running:
             self.cleanup_queue()
             time.sleep(30)
-            
+
     def command_received(self, command, payload):
         log.info(f"Command {command} received: {payload}")
-        
+
         # verify command in configuration
         if command not in self.commands_definition:
             log.error(f"Invalid command received: {command}")
             pub.sendMessage(TOPIC_COMMAND_RESULT, command=command, result="Invalid command")
             return
-        
+
         # verify command already in queue
         if any(item.Code == command for item in list(self.command_queue.queue)):
             log.error(f"Command already in queue: {command}")
@@ -79,7 +79,7 @@ class CommandService:
             command_to_insert = Command(command, command_config)
             self.command_queue.put(command_to_insert)
 
-            log.info(f"Command inserted in queue: {command_to_insert.to_json()}")
+            log.info(f"Command inserted in queue: {command_to_insert.to_json()} ({imei})")
 
         except Exception as ex:
             log.exception("Exception in command_received")
@@ -88,38 +88,38 @@ class CommandService:
     def cleanup_queue(self):
         for item in list(self.command_queue.queue):
             if (item.checkTimeout()):
-                log.error(f"Command timeout reached: {item.to_json()}")
+                log.error(f"Command timeout reached: {item.to_json()} ({imei})")
                 #self.command_queue.task_done()
                 self.command_queue.queue.remove(item)
-                pub.sendMessage(TOPIC_COMMAND_RESULT, command=item.Code, result=f"Command timeout reached, {item.to_json()}")
+                pub.sendMessage(TOPIC_COMMAND_RESULT, command=item.Code, result=f"Command timeout reached, {item.to_json()} ({imei})")
 
     def get_next_command(self):
         while not self.command_queue.empty():
             next_command = self.command_queue.get()
             if (next_command.checkTimeout()):
-                log.error(f"Command timeout reached: {next_command.to_json()}")
+                log.error(f"Command timeout reached: {next_command.to_json()} ({imei})")
                 self.command_queue.task_done()
-                pub.sendMessage(TOPIC_COMMAND_RESULT, command=next_command.Code, result=f"Command timeout reached, {next_command.to_json()}")
+                pub.sendMessage(TOPIC_COMMAND_RESULT, command=next_command.Code, result=f"Command timeout reached, {next_command.to_json()} ({imei})")
 
             return next_command
-        
+
         return None
-    
+
     def commands_to_execute(self):
         return not self.command_queue.empty()
 
     def command_executed(self, command, response):
-        log.info(f"Command executed: {command.to_json()}")
+        log.info(f"Command executed: {command.to_json()} ({imei})")
         self.command_queue.task_done()
-        pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Response <{response.decode()}>")
+        pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Response <{response.decode()}> from IMEI {imei}")
 
     def command_failed(self, command):
-        log.error(f"Command failed: {command.to_json()}")
+        log.error(f"Command failed: {command.to_json()} ({imei})")
         self.command_queue.task_done()
 
         if (not command.retry()):
-            log.error(f"Command retry limit reached: {command.to_json()}")
-            pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Command retry limit reached: {command.to_json()}")
-        else:    
-            log.info(f"Command retry: {command.to_json()}")
+            log.error(f"Command retry limit reached: {command.to_json()} ({imei})")
+            pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Command retry limit reached: {command.to_json()} ({imei})")
+        else:
+            log.info(f"Command retry: {command.to_json()} ({imei})")
             self.command_queue.put(command)

--- a/silence-server.py
+++ b/silence-server.py
@@ -1,54 +1,82 @@
 import json
 import time
 import platform
+from concurrent.futures import ThreadPoolExecutor
 
 from helpers.constants import *
 from helpers.logger import setup_logger
-
 from services.MQTTService import MQTTService
 from services.SilenceServerService import SilenceServerService
 
-def main():
+def start_services_for_imei(configuration, imei, index, logger):
+    """Start Silence Server and MQTT Service for a given IMEI number."""
+    logger.info(f"Logger configured for IMEI: {imei}")
 
-    print ("Silence-Server Main")
+    # Verwende BasePort und erzeuge eindeutige Ports für jede IMEI
+    port = configuration["TCPServer"]["BasePort"] + index
+    logger.info(f"Using port {port} for IMEI: {imei}")
+
+    # Start Silence Server mit dem individuellen Port
+    server_config = configuration["TCPServer"].copy()
+    server_config["serverPORT"] = port  # Fügt serverPORT hinzu
+
+    server = SilenceServerService(server_config, imei)
+    server.start()
+
+    # Start MQTT Service if enabled
+    mqttService = None
+    if configuration["MQTT"]["Enabled"]:
+        logger.info(f"Starting MQTT for IMEI: {imei}")
+        mqttService = MQTTService(configuration["MQTT"], imei)
+        mqttService.start()
+
+    return server, mqttService
+
+def main():
+    print("Silence-Server Main")
 
     with open("configuration.json") as configurationFile:
         configuration = json.load(configurationFile)
         print(f"Configuration loaded: {configuration}")
 
+    # Creating and configuring logger
     logger = setup_logger(configuration["Logging"])
-    logger.debug("Logged configured")
+    logger.debug("Logger configured")
 
-    logger.info("Starting Silence Server")
-    server = SilenceServerService(configuration["TCPServer"], configuration["IMEI"])
-    server.start()
+    # Starting services for each IMEI in separate threads
+    imei_list = configuration["IMEI_List"]  # List of IMEI from the configuration file
+    logger.info(f"Starting services for IMEI list: {imei_list}")
 
-    if configuration["MQTT"]["Enabled"]:
-        logger.info("Starting MQTT")
-        mqttService = MQTTService(configuration["MQTT"], configuration["IMEI"])
-        mqttService.start()
+    servers_mqtt_services = []
+    with ThreadPoolExecutor(max_workers=len(imei_list)) as executor:
+        futures = []
+        for index, imei in enumerate(imei_list):
+            future = executor.submit(start_services_for_imei, configuration, imei, index, logger)
+            futures.append(future)
 
-    logger.info("Silence Server Started...!")
+        for future in futures:
+            servers_mqtt_services.append(future.result())
+
+    logger.info("All Silence Servers and MQTT Services started...")
 
     try:
         while True:
             time.sleep(0.1)
-            pass
     except KeyboardInterrupt:
-        print("KeyboardInterrupt in main, terminate...")
-        
-        if server:
-            server.stop()
+        print("KeyboardInterrupt in main, terminating...")
 
-        if mqttService:
-            mqttService.stop()
-        
+        # Stopping all Server- und MQTT Services
+        for server, mqttService in servers_mqtt_services:
+            if server:
+                server.stop()
+            if mqttService:
+                mqttService.stop()
+
         exit(0)
 
 if __name__ == "__main__":
-
-    print (f"Python version: {platform.python_version()}")
-    print (f"Silence-Server version: {VERSION}")
+    print(f"Python version: {platform.python_version()}")
+    print(f"Silence-Server version: {VERSION}")
 
     try:
         print("Silence-Server - Main Start")

--- a/silence-server.py
+++ b/silence-server.py
@@ -12,13 +12,13 @@ def start_services_for_imei(configuration, imei, index, logger):
     """Start Silence Server and MQTT Service for a given IMEI number."""
     logger.info(f"Logger configured for IMEI: {imei}")
 
-    # Verwende BasePort und erzeuge eindeutige Ports für jede IMEI
+    # Use BasePort and create unique ports for each IMEI
     port = configuration["TCPServer"]["BasePort"] + index
     logger.info(f"Using port {port} for IMEI: {imei}")
 
-    # Start Silence Server mit dem individuellen Port
+    # Start Silence Server with individual port
     server_config = configuration["TCPServer"].copy()
-    server_config["serverPORT"] = port  # Fügt serverPORT hinzu
+    server_config["serverPORT"] = port  # adding serverPORT
 
     server = SilenceServerService(server_config, imei)
     server.start()


### PR DESCRIPTION
Added the functionality to handle and process multiple IMEI numbers at the same time. A separate thread is started for each IMEI included in the configuration.json file. The log output has been modified so that it is clear which thread (or which IMEI / vehicle) triggered which log line. Error handling was improved in helpers/logger.py if file logging is enabled and the "logs" directory doesn't exist yet. Furthermore, I translated the Italian comments to English and deleted some whitespace in the code.