### PR TITLE
feat: new SYNC command + fixes (CommandService crash, bundled Z-frame decoding)

### DIFF
--- a/helpers/commands_definition.json
+++ b/helpers/commands_definition.json
@@ -4,6 +4,11 @@
         "maxretry": 3,
         "timeout": 60
     },
+    "SYNC": {
+        "command": "$STMS\r\n",
+        "maxretry": 3,
+        "timeout": 60
+    },
     "TURN_ON_SCOOTER": {
         "command": "$PWON,4\r\n",
         "maxretry": 3,

--- a/helpers/messageParser.py
+++ b/helpers/messageParser.py
@@ -24,6 +24,14 @@ class MessageParser:
         with open(os.path.join(os.path.dirname(__file__), "RCAN_definition.json")) as RCAN_message_configuration:
             self.RCAN_message_configuration = json.load(RCAN_message_configuration)
 
+        # Valid single-frame lengths derived from decode config — used to detect bundled frames.
+        self._valid_z_lengths = {
+            l
+            for p in self.message_decode.values()
+            for mt in p["message_type"]
+            for l in mt["message_lenght"]
+        }
+
         # Fields populated by extended CAN polling (_parse_extended_can).
         # These are reset to "None" when the scooter is off so consumers
         # don't see stale values (e.g. RPM=1341, driveMode=SPORT while
@@ -44,7 +52,9 @@ class MessageParser:
             # multiple Z sub-frames get buffered and read as one big frame.
             # Format: Z[len_hi][len_lo][count][sub0][sub1]...[checksum]
             # Extract last sub-frame (most recent) and wrap in valid Z header.
-            if len(data) > 200 and data[0] == 0x5A and len(data) >= 4:
+            # Fix: check sub_count > 1 and not a known single-frame size,
+            # instead of len > 200 (misses 182-byte dual-frame packets).
+            if data[0] == 0x5A and len(data) >= 4 and len(data) not in self._valid_z_lengths:
                 sub_count = data[3]
                 if sub_count > 1:
                     sub_size = (len(data) - 4 - 2) // sub_count  # 4=header, 2=checksum

--- a/helpers/messageParser.py
+++ b/helpers/messageParser.py
@@ -116,6 +116,13 @@ class MessageParser:
             try:
                 data = data.decode()
 
+                # $STMS snapshot frame (forced sync via the SYNC command).
+                # Full status in one CSV line; decoded separately because the
+                # field layout differs entirely from $RCAN.
+                if data.startswith("$STMS,"):
+                    self._parse_stms(data)
+                    return
+
                 self._parse_extended_can(data)
 
                 for parameter in self.RCAN_message_configuration:
@@ -130,6 +137,71 @@ class MessageParser:
 
             except Exception:
                 log.exception(f"Exception in handling message protocol astra {data}")
+
+    def _parse_stms(self, data):
+        """Decode a $STMS snapshot frame and publish scooter status.
+
+        Field indices reverse-engineered then cross-checked against live
+        Z-protocol telemetry from the same scooter:
+          SOC=82, Vbat=55.6 (556/10), Tmax=25, Tmin=24, range=109,
+          charged=331.5425 (1193553/3600), regen=28.2425 (101673/3600),
+          discharged=321.8067 (1158504/3600), VIN=UCYSxxxxxxxxxxxxx (17 chars).
+
+        Example frame:
+          $STMS,0,82,25,24,556,0,435036987,0,0,330,330,0,109,0,
+                1193553,101673,1158504,22,<ICCID>,<phone>,<VIN>
+
+        Indices 7 (large counter), 8-12 and 14 are unidentified and left
+        untouched so they don't clobber good Z data — notably odo, which
+        $STMS does not carry (Z odo=6345 km != field 7).
+        """
+        parts = data.strip().split(",")
+
+        # (csv_index, parameter_key, divider)
+        numeric_fields = [
+            (1, "status", 1),
+            (2, "batterySOC", 1),
+            (3, "batteryTempMax", 1),
+            (4, "batteryTempMin", 1),
+            (5, "batteryVoltage", 10),
+            (6, "batteryCurrent", 10),
+            (13, "range", 1),
+            (15, "chargedEnergy", 3600),
+            (16, "RegeneratedEnergy", 3600),
+            (17, "DischargedEnergy", 3600),
+            (18, "ambientTemp", 1),
+        ]
+
+        parsed_any = False
+        for index, key, divider in numeric_fields:
+            if index >= len(parts):
+                continue
+            raw = parts[index].strip()
+            if raw == "":
+                continue
+            try:
+                self.parameters[key]["value"] = int(raw) / divider
+                parsed_any = True
+            except (ValueError, KeyError):
+                log.debug("STMS: cannot parse %s (index %s) value %r", key, index, raw)
+
+        # VIN is the last CSV field; sanity-check it looks like a Silence VIN
+        # before trusting it (guards against a truncated/garbled frame).
+        if len(parts) >= 2:
+            vin = parts[-1].strip()
+            if vin.startswith("UCYS") and len(vin) >= 10:
+                try:
+                    self.parameters["VIN"]["value"] = vin
+                    parsed_any = True
+                except KeyError:
+                    pass
+
+        if not parsed_any:
+            log.warning("STMS frame had no decodable fields: %s", data)
+            return
+
+        log.debug(f"Message $STMS parsed: {self.parameters}")
+        pub.sendMessage(TOPIC_SCOOTER_STATUS, scooter_status=self.parameters)
 
     def _parse_extended_can(self, data):
         """Parse extended CAN data from $RCAN responses."""

--- a/services/CommandService.py
+++ b/services/CommandService.py
@@ -79,7 +79,7 @@ class CommandService:
             command_to_insert = Command(command, command_config)
             self.command_queue.put(command_to_insert)
 
-            log.info(f"Command inserted in queue: {command_to_insert.to_json()} ({imei})")
+            log.info(f"Command inserted in queue: {command_to_insert.to_json()} ({self.IMEI})")
 
         except Exception as ex:
             log.exception("Exception in command_received")
@@ -88,18 +88,18 @@ class CommandService:
     def cleanup_queue(self):
         for item in list(self.command_queue.queue):
             if (item.checkTimeout()):
-                log.error(f"Command timeout reached: {item.to_json()} ({imei})")
+                log.error(f"Command timeout reached: {item.to_json()} ({self.IMEI})")
                 #self.command_queue.task_done()
                 self.command_queue.queue.remove(item)
-                pub.sendMessage(TOPIC_COMMAND_RESULT, command=item.Code, result=f"Command timeout reached, {item.to_json()} ({imei})")
+                pub.sendMessage(TOPIC_COMMAND_RESULT, command=item.Code, result=f"Command timeout reached, {item.to_json()} ({self.IMEI})")
 
     def get_next_command(self):
         while not self.command_queue.empty():
             next_command = self.command_queue.get()
             if (next_command.checkTimeout()):
-                log.error(f"Command timeout reached: {next_command.to_json()} ({imei})")
+                log.error(f"Command timeout reached: {next_command.to_json()} ({self.IMEI})")
                 self.command_queue.task_done()
-                pub.sendMessage(TOPIC_COMMAND_RESULT, command=next_command.Code, result=f"Command timeout reached, {next_command.to_json()} ({imei})")
+                pub.sendMessage(TOPIC_COMMAND_RESULT, command=next_command.Code, result=f"Command timeout reached, {next_command.to_json()} ({self.IMEI})")
 
             return next_command
 
@@ -109,17 +109,17 @@ class CommandService:
         return not self.command_queue.empty()
 
     def command_executed(self, command, response):
-        log.info(f"Command executed: {command.to_json()} ({imei})")
+        log.info(f"Command executed: {command.to_json()} ({self.IMEI})")
         self.command_queue.task_done()
-        pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Response <{response.decode()}> from IMEI {imei}")
+        pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Response <{response.decode()}> from IMEI {self.IMEI}")
 
     def command_failed(self, command):
-        log.error(f"Command failed: {command.to_json()} ({imei})")
+        log.error(f"Command failed: {command.to_json()} ({self.IMEI})")
         self.command_queue.task_done()
 
         if (not command.retry()):
-            log.error(f"Command retry limit reached: {command.to_json()} ({imei})")
-            pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Command retry limit reached: {command.to_json()} ({imei})")
+            log.error(f"Command retry limit reached: {command.to_json()} ({self.IMEI})")
+            pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Command retry limit reached: {command.to_json()} ({self.IMEI})")
         else:
-            log.info(f"Command retry: {command.to_json()} ({imei})")
+            log.info(f"Command retry: {command.to_json()} ({self.IMEI})")
             self.command_queue.put(command)

--- a/tests/test_commandService.py
+++ b/tests/test_commandService.py
@@ -1,0 +1,145 @@
+"""Unit tests for services.CommandService.
+
+Regression tests for the `imei` -> `self.IMEI` fix: every logging /
+result-reporting path in CommandService referenced a bare `imei` name
+that was never defined, so each of these methods raised
+`NameError: name 'imei' is not defined` as soon as it ran — tearing down
+the scooter listener thread right after a command was sent.
+
+These tests exercise all five affected paths (command_received,
+cleanup_queue, get_next_command, command_executed, command_failed) and
+assert that no exception escapes and that results are published with the
+correct IMEI.
+"""
+import pytest
+
+from helpers.command import Command
+from services.CommandService import CommandService
+import services.CommandService as cs_mod
+
+
+TEST_IMEI = "860873043967941"
+
+CMD_CONFIG = {"command": "$STMS\r\n", "maxretry": 3, "timeout": 60}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def published(monkeypatch):
+    """Capture pub.sendMessage calls as (args, kwargs) tuples."""
+    calls = []
+    monkeypatch.setattr(cs_mod.pub, "sendMessage",
+                        lambda *a, **kw: calls.append((a, kw)))
+    return calls
+
+
+@pytest.fixture
+def service():
+    svc = CommandService(configuration={}, IMEI=TEST_IMEI)
+    # start() loads this from disk and spawns a thread; unit tests
+    # inject the definition directly instead.
+    svc.commands_definition = {"SYNC": CMD_CONFIG}
+    return svc
+
+
+def make_queued_command(service, code="SYNC"):
+    """Put a command in the queue and take it, mirroring the real flow
+    (get_next_command -> execute -> command_executed/command_failed)."""
+    cmd = Command(code, CMD_CONFIG)
+    service.command_queue.put(cmd)
+    service.command_queue.get()
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# command_received
+# ---------------------------------------------------------------------------
+
+def test_command_received_enqueues_without_nameerror(service, published):
+    # Used to raise NameError on the "Command inserted in queue" log line.
+    service.command_received("SYNC", "")
+    assert service.command_queue.qsize() == 1
+
+
+def test_command_received_rejects_unknown_command(service, published):
+    service.command_received("NOT_A_COMMAND", "")
+    assert service.command_queue.qsize() == 0
+    assert any("Invalid command" in kw.get("result", "")
+               for _, kw in published)
+
+
+# ---------------------------------------------------------------------------
+# command_executed / command_failed
+# ---------------------------------------------------------------------------
+
+def test_command_executed_publishes_result_with_imei(service, published):
+    # Used to raise NameError while formatting the result message,
+    # killing the scooter listener thread after every executed command.
+    cmd = make_queued_command(service)
+    service.command_executed(cmd, b"$STMS,0,82,25,24,556")
+
+    assert len(published) == 1
+    _, kw = published[0]
+    assert kw["command"] == "SYNC"
+    assert TEST_IMEI in kw["result"]
+
+
+def test_command_failed_requeues_for_retry(service, published):
+    cmd = make_queued_command(service)
+    service.command_failed(cmd)  # retry_attempts 0 -> 1, below maxretry
+
+    assert service.command_queue.qsize() == 1
+    assert published == []  # no result published while retries remain
+
+
+def test_command_failed_reports_retry_limit_with_imei(service, published):
+    cmd = make_queued_command(service)
+    cmd.retry_attempts = cmd.maxretry  # next retry() returns False
+
+    service.command_failed(cmd)
+
+    assert service.command_queue.qsize() == 0
+    assert len(published) == 1
+    _, kw = published[0]
+    assert "retry limit" in kw["result"].lower()
+    assert TEST_IMEI in kw["result"]
+
+
+# ---------------------------------------------------------------------------
+# Timeout paths (cleanup_queue / get_next_command)
+# ---------------------------------------------------------------------------
+
+def expired_command():
+    cmd = Command("SYNC", CMD_CONFIG)
+    cmd.TSInserted -= CMD_CONFIG["timeout"] + 10
+    return cmd
+
+
+def test_cleanup_queue_drops_expired_command(service, published):
+    service.command_queue.put(expired_command())
+
+    service.cleanup_queue()
+
+    assert service.command_queue.qsize() == 0
+    assert any("timeout" in kw.get("result", "").lower() and TEST_IMEI in kw["result"]
+               for _, kw in published)
+
+
+def test_get_next_command_reports_expired_command(service, published):
+    service.command_queue.put(expired_command())
+
+    cmd = service.get_next_command()
+
+    # Current behaviour: the expired command is still returned (the
+    # caller re-checks the timeout), but the result must be published
+    # without raising.
+    assert cmd is not None
+    assert any("timeout" in kw.get("result", "").lower()
+               for _, kw in published)
+
+
+def test_get_next_command_empty_queue_returns_none(service):
+    assert service.get_next_command() is None

--- a/tests/test_messageParser.py
+++ b/tests/test_messageParser.py
@@ -289,14 +289,13 @@ def test_normal_z_frame_not_touched_by_debundler(parser):
     assert parser.parameters["status"]["value"] == 4
 
 
-@pytest.mark.parametrize("sub_count", [3, 5, 7, 11])
+@pytest.mark.parametrize("sub_count", [2, 3, 5, 7, 11])
 def test_bundled_frame_extracts_last_subframe(parser, sub_count):
-    # The debundler only kicks in for frames > 200 bytes. Real-world
-    # captures showed 2-11 sub-records per frame depending on how much
-    # $RCAN polling delayed the comm loop. Verify the math holds for
-    # representative sub_count values (2 gives 182 bytes, below the
-    # 200-byte threshold, so not debundled; 3 is the minimum that
-    # triggers the code path).
+    # The debundler kicks in for any Z frame whose length is not a known
+    # single-frame size. Real-world captures showed 2-11 sub-records per
+    # frame depending on how much $RCAN polling delayed the comm loop.
+    # sub_count=2 (182 bytes) is the regression case: the old
+    # `len > 200` check missed it and the packet was silently dropped.
     sub_size = 88
     total_len = 4 + sub_count * sub_size + 2
 
@@ -337,7 +336,7 @@ def test_bundled_frame_degenerate_sub_count_does_not_crash(parser):
     # Attacker / malformed input: sub_count too high for the payload,
     # leading to `sub_size = (len - 4 - 2) // sub_count = 0`. The guard
     # `if sub_size > 0` must prevent any slice manipulation.
-    total_len = 250  # > 200 so we enter the debundling branch
+    total_len = 250  # not a known single-frame length -> debundling branch
     frame = bytearray(total_len)
     frame[0] = 0x5A
     frame[1] = (total_len >> 8) & 0xFF

--- a/tests/test_messageParser.py
+++ b/tests/test_messageParser.py
@@ -469,3 +469,61 @@ def test_get_scooter_off_status_getter(parser):
     assert parser.get_scooter_off_status() is True
     parser.scooter_off = False
     assert parser.get_scooter_off_status() is False
+
+
+# ---------------------------------------------------------------------------
+# $STMS snapshot frame (SYNC command response)
+# ---------------------------------------------------------------------------
+
+STMS_FRAME = (
+    b"$STMS,0,82,25,24,556,0,435036987,0,0,330,330,0,109,0,"
+    b"1193553,101673,1158504,22,89340760000000000000,+34600000000,"
+    b"UCYS1234567890123\r\n"
+)
+
+
+def test_stms_frame_decodes_snapshot_fields(parser):
+    parser.parse_message_from_scooter_protocol_astra(STMS_FRAME)
+    p = parser.parameters
+    assert p["batterySOC"]["value"] == 82
+    assert p["batteryTempMax"]["value"] == 25
+    assert p["batteryTempMin"]["value"] == 24
+    assert p["batteryVoltage"]["value"] == 55.6
+    assert p["range"]["value"] == 109
+    assert p["chargedEnergy"]["value"] == pytest.approx(331.5425)
+    assert p["RegeneratedEnergy"]["value"] == pytest.approx(28.2425)
+    assert p["DischargedEnergy"]["value"] == pytest.approx(321.8067, abs=1e-4)
+    assert p["ambientTemp"]["value"] == 22
+    assert p["VIN"]["value"] == "UCYS1234567890123"
+
+
+def test_stms_publishes_status(parser, monkeypatch):
+    calls = []
+    import helpers.messageParser as mp
+    monkeypatch.setattr(mp.pub, "sendMessage", lambda *a, **kw: calls.append((a, kw)))
+    parser.parse_message_from_scooter_protocol_astra(STMS_FRAME)
+    assert len(calls) == 1
+
+
+def test_stms_leaves_unidentified_fields_untouched(parser):
+    # $STMS does not carry odo (field 7 is an unrelated large counter);
+    # an odo previously read from Z telemetry must survive a snapshot.
+    parser.parameters["odo"]["value"] = 6345.0
+    parser.parse_message_from_scooter_protocol_astra(STMS_FRAME)
+    assert parser.parameters["odo"]["value"] == 6345.0
+
+
+def test_stms_rejects_implausible_vin(parser):
+    # A truncated/garbled last field must not overwrite a known-good VIN.
+    parser.parameters["VIN"]["value"] = "UCYS_KNOWN_GOOD00"
+    frame = STMS_FRAME.replace(b"UCYS1234567890123", b"GARBLED")
+    parser.parse_message_from_scooter_protocol_astra(frame)
+    assert parser.parameters["VIN"]["value"] == "UCYS_KNOWN_GOOD00"
+
+
+def test_stms_undecodable_frame_does_not_publish(parser, monkeypatch):
+    calls = []
+    import helpers.messageParser as mp
+    monkeypatch.setattr(mp.pub, "sendMessage", lambda *a, **kw: calls.append((a, kw)))
+    parser.parse_message_from_scooter_protocol_astra(b"$STMS,,\r\n")
+    assert calls == []


### PR DESCRIPTION
## Summary

This PR bundles **3 independent fixes**, each validated on a live Silence S01+ (MY22) and covered by unit tests.

| # | Type | Scope | Impact |
|---|------|-------|--------|
| 1 | ✨ Feat | `$STMS` / `SYNC` | Snapshot decoding + on-demand sync command |
| 2 | 🐛 Fix | `CommandService` | `NameError` crash after every command → TCP disconnect |
| 3 | 🐛 Fix | Z parser | Bundled Z packets (182 B) silently dropped |

> **Validation:** `python -m pytest tests/ -q` → **57 passed** (43 pre-existing untouched + 14 new).

---

## Background

The original goal of this PR was simply to bring the **synchronisation feature** from the official Silence app into [a dirty personnal project using this repo](https://github.com/Balou866/SilenceDashboard)— a missing functionnality. 
While moving on my project, I stumbled on a couple of bugs along the way and fixed them as a bonus.

Full disclosure: this is my first contribution of this kind. I had no prior experience with the codebase or the Z protocol, so Claude did most of the heavy lifting on code generation and validation — please review with that in mind - althought I have been testing and using it for months on my project, without noticed issues.

---

## 1 · `$STMS` — snapshot decoding + `SYNC` command

### Context
The official app's "synchronise" button makes the cloud send `$STMS`, to which the scooter replies with a **full snapshot on a single CSV line**. The Astra parser had no decoder, so the reply was **silently dropped**.

### What's added

**A. `_parse_stms()`** — decodes fields (cross-checked against Z-protocol telemetry from the same scooter):

| Field | From `$STMS` |
|-------|--------------|
| SOC | ✓ |
| Battery voltage | ✓ |
| Battery temp min / max | ✓ |
| Range | ✓ |
| Charged / regenerated / discharged energy (Wh, `/3600`) | ✓ |
| Ambient temp | ✓ |
| VIN | sanity-checked against `UCYS` prefix before trusting |

> Unidentified indices are **intentionally left untouched** so they don't clobber good Z
> data — notably `odo`, which `$STMS` does not carry.

**B. `SYNC` command** (`$STMS\r\n`) in `commands_definition.json`:
request a full snapshot on demand over MQTT (`.../command/SYNC`) without waiting for the next poll — the same mechanism the official app uses.

### Tests
- Decoding of a real (anonymized) frame
- Publish behaviour
- `odo` preservation
- Garbled-VIN rejection
- Undecodable frame → no publish

---

## 2 · `CommandService` — `NameError` crash after every command

### Problem
`command_received()` enqueues the command *before* the crashing line, so the command is still sent. But `command_executed()` / `command_failed()` crash **while reporting the result**. The `NameError` propagates up the listener thread and **tears down the TCP connection** right after sending.

### Cause
`__init__` stores the IMEI in `self.IMEI`, but **11 f-strings** in the logging / reporting paths reference `imei` (never defined): 
NameError:` name 'imei' is not `defined

Other services are consistent (`MQTTService` → `self.imei`, `DBService` /
`SilenceServerService` → `self.IMEI`). Only `CommandService` is mismatched.

> The bug went unnoticed because fire-and-forget commands appear to work (the effect is
> already delivered); only commands whose **reply must be read back** lose it when the
> thread dies.

### Fix
Reference `self.IMEI` in all **11** spots.

### Tests — `tests/test_commandService.py` (new)
Covers all **5** affected paths, each of which raised `NameError` before:

| Path | Asserts |
|------|---------|
| `command_received` | Result published with correct IMEI |
| `cleanup_queue` | — |
| `get_next_command` | — |
| `command_executed` | — |
| `command_failed` | — |

---

## 3 · Z parser — bundled-frame detection by length table

### Problem
Bundled Z packets (`Z[len_hi][len_lo][count][sub0][sub1]…[checksum]`) were only unbundled when `len(data) > 200`. 
A **dual-frame packet is 182 bytes**, so it fell through to single-frame parsing: its length matched no entry in `Z_protocol_message_decode.json` and the whole packet was **silently dropped**. 

### Fix
- Build the **set of valid single-frame lengths** from the decode config at init;
- Treat any Z packet of **unknown length** as a bundled-frame candidate
  (the existing `sub_count > 1` guard still applies).

### Tests
Added the regression case `sub_count=2` (182 B) to the debundling parametrize.
Existing cases still pass: single-frame, degenerate `sub_count`, 250-byte edge.

---

## 📋 Review checklist

- [x] 3 independent changes (reviewable commit-by-commit)
- [x] Each fix reproduced → fixed → tested
- [x] `57 passed` — no regression
- [x] Validated on a live scooter (Silence S01+ MY22)