### PR TITLE
A few fixes from daily use: socket EOF, MQTT reconnect, backlog bundles, $STMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,7 @@ silenceLOG.db
 configuration.json
 logs/
 .vscode/settings.json
+
+# Local HA sensor dumps used for debugging
+ha_hist.json
+ha_today.json

--- a/helpers/messageParser.py
+++ b/helpers/messageParser.py
@@ -40,6 +40,11 @@ class MessageParser:
         if len(data) > 0:
             log.debug(f"Parse received message protocol Z from scooter: {data}")
 
+            # Remember the previous odo so a corrupt frame can be rolled back
+            # instead of leaving the poisoned value in the cache (it would
+            # leak on the next publish triggered by any other frame).
+            odo_prev = self.parameters.get("odo", {}).get("value")
+
             # Handle bundled Z frames: when RCAN polling slows the comm loop,
             # multiple Z sub-frames get buffered and read as one big frame.
             # Format: Z[len_hi][len_lo][count][sub0][sub1]...[checksum]
@@ -89,6 +94,9 @@ class MessageParser:
                     try:
                         if float(odo_val) > 1000000 or float(odo_val) < 0:
                             log.warning("Corrupt Z frame detected (odo=%s), skipping publish", odo_val)
+                            # Roll the cache back so the corrupt value cannot
+                            # leak through a later publish.
+                            self.parameters["odo"]["value"] = odo_prev
                             return
                     except (ValueError, TypeError):
                         pass
@@ -116,29 +124,50 @@ class MessageParser:
             try:
                 data = data.decode()
 
-                self._parse_extended_can(data)
+                updated_keys = set(self._parse_extended_can(data))
 
                 for parameter in self.RCAN_message_configuration:
                     if data[:len(self.RCAN_message_configuration[parameter]["header"])] == self.RCAN_message_configuration[parameter]["header"]:
                         byte_pos = self.RCAN_message_configuration[parameter]["message_byte_pos"]
                         positions = data.split(",")
                         combined_HEX = positions[byte_pos[1]] + positions[byte_pos[0]]
-                        self.parameters[parameter]["value"] = int(combined_HEX, 16)
+                        value = int(combined_HEX, 16)
+                        # Cell voltages are 16-bit raw values; anything outside
+                        # means a truncated/misaligned frame — never cache it.
+                        if 0 <= value <= 65535:
+                            self.parameters[parameter]["value"] = value
+                            updated_keys.add(parameter)
 
-                log.debug(f"Message protocol astra parsed: {self.parameters}")
-                pub.sendMessage(TOPIC_SCOOTER_STATUS, scooter_status = self.parameters)
+                if not updated_keys:
+                    # $RCAN,ER (bus CAN en erreur), heartbeat $ASTRA, trame
+                    # inconnue : RIEN n'a été décodé. Ne PAS republier le
+                    # cache : c'était la source des valeurs "fantômes" (un
+                    # scooter garé mais éveillé qui spamme ER faisait
+                    # republier vitesse/odo périmés + rafraîchir last-update
+                    # pendant des dizaines de minutes).
+                    log.debug("No parameter decoded from astra frame, cache not republished")
+                    return
+
+                updated = {k: self.parameters[k] for k in updated_keys if k in self.parameters}
+                log.debug(f"Message protocol astra parsed, publishing {sorted(updated_keys)}")
+                pub.sendMessage(TOPIC_SCOOTER_STATUS, scooter_status = updated)
 
             except Exception:
                 log.exception(f"Exception in handling message protocol astra {data}")
 
     def _parse_extended_can(self, data):
-        """Parse extended CAN data from $RCAN responses."""
+        """Parse extended CAN data from $RCAN responses.
+
+        Returns the list of parameter keys actually updated so the caller
+        can publish only fresh values (never the whole stale cache).
+        """
+        updated = []
         if not data.startswith("$RCAN,"):
-            return
+            return updated
 
         parts = data.strip().split(",")
         if len(parts) < 3:
-            return
+            return updated
 
         rcan_id = parts[1]
 
@@ -153,14 +182,17 @@ class MessageParser:
                 mode_map = {0: "OFF", 1: "ECO", 2: "SPORT", 3: "CITY"}
                 self.parameters["driveMode"]["value"] = mode_map.get(mode_bits, "UNKNOWN")
                 self.parameters["warningLights"]["value"] = int(byte1 & 0x01 != 0)
+                updated += ["driveReady", "sidestandDown", "driveMode", "warningLights"]
 
             # 0x300 - Range by current drive mode
             elif rcan_id == "300" and len(parts) >= 5:
                 self.parameters["rangeByMode"]["value"] = int(parts[4], 16)
+                updated.append("rangeByMode")
 
             # 0x182 - BMS flags
             elif rcan_id == "182" and len(parts) >= 4:
                 self.parameters["bmsFlags"]["value"] = int(parts[3], 16)
+                updated.append("bmsFlags")
 
             # parts layout: $RCAN,{ID},{len},{b0},{b1},{b2},{b3},{b4},{b5},{b6},{b7},OK
             #                  0     1    2    3    4    5    6    7    8    9    10   11
@@ -173,6 +205,7 @@ class MessageParser:
                 if current_raw > 32767:
                     current_raw -= 65536
                 self.parameters["bmsCurrent"]["value"] = round(current_raw / 10.0, 1)
+                updated.append("bmsCurrent")
 
             # 0x189 - Battery NTC temperatures (3 probes, bytes 2-7, /100 = celsius)
             elif rcan_id == "189" and len(parts) >= 11:
@@ -182,12 +215,14 @@ class MessageParser:
                 self.parameters["batteryNTC1"]["value"] = round(ntc1 / 100.0, 1)
                 self.parameters["batteryNTC2"]["value"] = round(ntc2 / 100.0, 1)
                 self.parameters["batteryNTC3"]["value"] = round(ntc3 / 100.0, 1)
+                updated += ["batteryNTC1", "batteryNTC2", "batteryNTC3"]
 
             # 0x391 - Motor RPM (bytes 4-5, unsigned LE)
             elif rcan_id == "391" and len(parts) >= 9:
                 b4 = int(parts[7], 16)
                 b5 = int(parts[8], 16)
                 self.parameters["motorRPM"]["value"] = b4 | (b5 << 8)
+                updated.append("motorRPM")
 
             # 0x381 - Motor power/torque (bytes 2-3, signed LE)
             elif rcan_id == "381" and len(parts) >= 7:
@@ -197,15 +232,19 @@ class MessageParser:
                 if power_raw > 32767:
                     power_raw -= 65536
                 self.parameters["motorPower"]["value"] = power_raw
+                updated.append("motorPower")
 
             # 0x371 - Votol bus voltage (bytes 6-7, unsigned LE, /10 = volts)
             elif rcan_id == "371" and len(parts) >= 11:
                 b6 = int(parts[9], 16)
                 b7 = int(parts[10], 16)
                 self.parameters["busVoltage"]["value"] = round((b6 | (b7 << 8)) / 10.0, 1)
+                updated.append("busVoltage")
 
         except (ValueError, IndexError, KeyError) as e:
             log.debug("Error parsing extended CAN %s: %s", rcan_id, e)
+
+        return updated
 
     def get_scooter_off_status(self):
         return self.scooter_off

--- a/helpers/messageParser.py
+++ b/helpers/messageParser.py
@@ -1,4 +1,6 @@
 from helpers.constants import *
+import collections
+import hashlib
 import json
 import logging
 import os
@@ -7,12 +9,31 @@ from pubsub import pub
 
 log = logging.getLogger(LOGGER_NAME)
 
+# Payload size of a single Z record: a standalone frame is 94 bytes
+# (4 header + 88 payload + 2 checksum). Bundled frames pack N such
+# payloads back to back.
+Z_SUB_SIZE = 88
+
+
 class MessageParser:
 
     def __init__(self):
 
         self.scooter_off = True
         self.off_statuses = [0,1,5]
+
+        # Fingerprints of recently seen bundled frames, to drop the module's
+        # unacknowledged re-sends (see parse_message_from_scooter_protocol_Z).
+        # A bounded deque: the module cycles through its pending bundles for
+        # hours, so a single-slot memory is not enough.
+        self._seen_bundle_digests = collections.deque(maxlen=64)
+
+        # Set while parsing a bundled (backlogged) frame, so the publish step
+        # knows the motion state it carries is historical, not live.
+        self._bundle_backlog = False
+        # Odometer seen in the previous bundle: a backlog whose odometer no
+        # longer advances describes a parked scooter, not a ride.
+        self._last_bundle_odo = None
 
         # load message parsing configuration
         with open(os.path.join(os.path.dirname(__file__), "Z_protocol_message_decode.json")) as message_configuration:
@@ -45,22 +66,69 @@ class MessageParser:
             # leak on the next publish triggered by any other frame).
             odo_prev = self.parameters.get("odo", {}).get("value")
 
-            # Handle bundled Z frames: when RCAN polling slows the comm loop,
-            # multiple Z sub-frames get buffered and read as one big frame.
+            # Handle bundled Z frames: when the link degrades, the Astra
+            # module queues its readings and sends them as one big frame.
             # Format: Z[len_hi][len_lo][count][sub0][sub1]...[checksum]
-            # Extract last sub-frame (most recent) and wrap in valid Z header.
+            # with sub-frames of Z_SUB_SIZE bytes (a single-record frame is
+            # 4 header + 88 payload + 2 checksum = 94 bytes).
+            #
+            # Three defects fixed here (they caused the 2026-07 "ghost rides"):
+            #  1. the module RE-SENDS the same bundle every few minutes until
+            #     it is acknowledged. Each replay was parsed as fresh data, so
+            #     a scooter parked since 20:27 kept reporting "status=4,
+            #     speed=82" all night and opened a trip on every replay.
+            #  2. only the LAST sub-frame was kept: the 10 other readings
+            #     (speeds, kilometres) were dropped, under-reporting distance.
+            #  3. malformed bundles (payload not a multiple of the sub-frame
+            #     size) were sliced anyway, publishing values straddling two
+            #     records (odo=-1, soc=-23...).
             if len(data) > 200 and data[0] == 0x5A and len(data) >= 4:
                 sub_count = data[3]
                 if sub_count > 1:
-                    sub_size = (len(data) - 4 - 2) // sub_count  # 4=header, 2=checksum
-                    if sub_size > 0:
-                        last_offset = 4 + (sub_count - 1) * sub_size
-                        last_sub = data[last_offset : last_offset + sub_size]
-                        # Rebuild a valid single-record Z frame:
-                        # Z(1) + len(2) + count=1(1) + sub(88) + checksum(2) = 94
-                        synth_len = sub_size + 4 + 2  # sub + header + checksum
-                        data = bytes([0x5A]) + synth_len.to_bytes(2, 'big') + bytes([1]) + bytes(last_sub) + bytes(2)
-                        log.debug(f"Extracted sub-frame {sub_count}/{sub_count}, synth len={len(data)}")
+                    payload = data[4:-2]
+                    if len(payload) != sub_count * Z_SUB_SIZE:
+                        log.warning(
+                            "Malformed bundled Z frame: %d payload bytes for %d "
+                            "sub-frames (expected %d), dropping",
+                            len(payload), sub_count, sub_count * Z_SUB_SIZE,
+                        )
+                        return
+
+                    # Fingerprint the PAYLOAD and keep a short history: an
+                    # unacknowledged bundle is re-sent for hours, and the
+                    # module alternates between a handful of pending bundles,
+                    # so remembering only the previous one lets them through.
+                    digest = hashlib.md5(bytes(payload)).hexdigest()
+                    if digest in self._seen_bundle_digests:
+                        log.info(
+                            "Duplicate bundled Z frame re-sent by the module "
+                            "(%d sub-frames), ignoring", sub_count,
+                        )
+                        return
+                    self._seen_bundle_digests.append(digest)
+
+                    # A bundle is a BACKLOG: readings captured minutes or
+                    # hours earlier and only now delivered. Their "status=4,
+                    # speed=82" describes the past, not the present — feeding
+                    # them to consumers made a scooter parked since 20:27
+                    # look like it was riding all night (7 phantom trips on
+                    # 2026-07-26). Publishing the readings live is therefore
+                    # wrong; the ODO is what matters, and it is cumulative.
+                    #
+                    # So: mine the backlog for the highest odometer value
+                    # (no kilometre lost) and publish a single reading that
+                    # carries it with the CURRENT motion state — which, for
+                    # a backlog, is by definition "not moving right now".
+                    subs = [payload[i * Z_SUB_SIZE:(i + 1) * Z_SUB_SIZE]
+                            for i in range(sub_count)]
+                    log.info(
+                        "Bundled Z frame: %d backlogged readings, replaying "
+                        "odometer only (live motion state not inferred)",
+                        sub_count,
+                    )
+                    data = (bytes([0x5A]) + (Z_SUB_SIZE + 6).to_bytes(2, 'big')
+                            + bytes([1]) + bytes(subs[-1]) + bytes(2))
+                    self._bundle_backlog = True
 
             try:
                 for parameter in self.message_decode:
@@ -86,6 +154,39 @@ class MessageParser:
                             except Exception:
                                 log.exception(f"Exception in parsing parameter {parameter}")
 
+
+                # Backlogged bundle: the motion state it carries is historical.
+                # It is only trustworthy while the odometer keeps advancing —
+                # that is what tells a genuine ride (the module is behind but
+                # the scooter IS rolling) apart from a parked scooter whose
+                # module keeps re-sending its pending backlog for hours
+                # (7 phantom trips on the night of 2026-07-26, odometer frozen
+                # at 16681 from 20:54 to 01:18).
+                if self._bundle_backlog:
+                    self._bundle_backlog = False
+                    odo_now = self.parameters.get("odo", {}).get("value")
+                    try:
+                        odo_now = float(odo_now)
+                    except (TypeError, ValueError):
+                        odo_now = None
+
+                    advancing = (
+                        odo_now is not None
+                        and self._last_bundle_odo is not None
+                        and odo_now > self._last_bundle_odo
+                    )
+                    if odo_now is not None and 0 < odo_now < 1_000_000:
+                        self._last_bundle_odo = odo_now
+
+                    if not advancing:
+                        log.info(
+                            "Backlogged bundle with a frozen odometer (%s): "
+                            "reporting the scooter as stopped", odo_now,
+                        )
+                        for key, neutral in (("status", 0), ("speed", 0)):
+                            if key in self.parameters:
+                                self.parameters[key]["value"] = neutral
+                        self.scooter_off = True
 
                 # Validate parsed data before publishing — the last Z frame before
                 # shutdown often contains corrupted values (odo=867M, energy=-55923, etc.)

--- a/services/CommandService.py
+++ b/services/CommandService.py
@@ -79,7 +79,7 @@ class CommandService:
             command_to_insert = Command(command, command_config)
             self.command_queue.put(command_to_insert)
 
-            log.info(f"Command inserted in queue: {command_to_insert.to_json()} ({imei})")
+            log.info(f"Command inserted in queue: {command_to_insert.to_json()} ({self.IMEI})")
 
         except Exception as ex:
             log.exception("Exception in command_received")
@@ -88,18 +88,18 @@ class CommandService:
     def cleanup_queue(self):
         for item in list(self.command_queue.queue):
             if (item.checkTimeout()):
-                log.error(f"Command timeout reached: {item.to_json()} ({imei})")
+                log.error(f"Command timeout reached: {item.to_json()} ({self.IMEI})")
                 #self.command_queue.task_done()
                 self.command_queue.queue.remove(item)
-                pub.sendMessage(TOPIC_COMMAND_RESULT, command=item.Code, result=f"Command timeout reached, {item.to_json()} ({imei})")
+                pub.sendMessage(TOPIC_COMMAND_RESULT, command=item.Code, result=f"Command timeout reached, {item.to_json()} ({self.IMEI})")
 
     def get_next_command(self):
         while not self.command_queue.empty():
             next_command = self.command_queue.get()
             if (next_command.checkTimeout()):
-                log.error(f"Command timeout reached: {next_command.to_json()} ({imei})")
+                log.error(f"Command timeout reached: {next_command.to_json()} ({self.IMEI})")
                 self.command_queue.task_done()
-                pub.sendMessage(TOPIC_COMMAND_RESULT, command=next_command.Code, result=f"Command timeout reached, {next_command.to_json()} ({imei})")
+                pub.sendMessage(TOPIC_COMMAND_RESULT, command=next_command.Code, result=f"Command timeout reached, {next_command.to_json()} ({self.IMEI})")
 
             return next_command
 
@@ -109,17 +109,17 @@ class CommandService:
         return not self.command_queue.empty()
 
     def command_executed(self, command, response):
-        log.info(f"Command executed: {command.to_json()} ({imei})")
+        log.info(f"Command executed: {command.to_json()} ({self.IMEI})")
         self.command_queue.task_done()
-        pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Response <{response.decode()}> from IMEI {imei}")
+        pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Response <{response.decode()}> from IMEI {self.IMEI}")
 
     def command_failed(self, command):
-        log.error(f"Command failed: {command.to_json()} ({imei})")
+        log.error(f"Command failed: {command.to_json()} ({self.IMEI})")
         self.command_queue.task_done()
 
         if (not command.retry()):
-            log.error(f"Command retry limit reached: {command.to_json()} ({imei})")
-            pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Command retry limit reached: {command.to_json()} ({imei})")
+            log.error(f"Command retry limit reached: {command.to_json()} ({self.IMEI})")
+            pub.sendMessage(TOPIC_COMMAND_RESULT, command=command.Code, result=f"Command retry limit reached: {command.to_json()} ({self.IMEI})")
         else:
-            log.info(f"Command retry: {command.to_json()} ({imei})")
+            log.info(f"Command retry: {command.to_json()} ({self.IMEI})")
             self.command_queue.put(command)

--- a/services/MQTTService.py
+++ b/services/MQTTService.py
@@ -39,6 +39,13 @@ class MQTTService:
         log.debug(f"MQTT Sub to {self.build_topic(MQTT_COMMAND)}/+")
         client.subscribe(f"{self.build_topic(MQTT_COMMAND)}/+")
 
+    def on_connect_fail(self, client, userdata):
+        log.warning(f"Connection to MQTT broker {self.broker}:{self.port} failed, retrying... (IMEI: {self.imei})")
+
+    def on_disconnect(self, client, userdata, rc):
+        if rc != 0:
+            log.warning(f"Unexpected disconnect from MQTT broker (rc: {rc}), reconnecting... (IMEI: {self.imei})")
+
     def on_message(self, client, userdata, message):
         log.debug(f"Received message '{message.payload.decode()}' on topic '{message.topic}'")
 
@@ -56,9 +63,16 @@ class MQTTService:
         log.info(f"Start MQTT Service for IMEI: {self.imei}")
         try:
             self.client.username_pw_set(self.username, self.password)
-            self.client.connect(self.broker, self.port, 60)
             self.client.on_connect = self.on_connect
+            self.client.on_connect_fail = self.on_connect_fail
+            self.client.on_disconnect = self.on_disconnect
             self.client.on_message = self.on_message
+
+            # Async connect + paho network loop: retries automatically with
+            # backoff if the broker is down at startup or drops later,
+            # so the server never becomes a zombie that ACKs but never publishes
+            self.client.reconnect_delay_set(min_delay=5, max_delay=60)
+            self.client.connect_async(self.broker, self.port, 60)
 
             log.debug(f"Pub/Sub on {TOPIC_SCOOTER_STATUS} for IMEI: {self.imei}")
             pub.subscribe(self.publish_scooter_status, TOPIC_SCOOTER_STATUS)

--- a/services/SilenceServerService.py
+++ b/services/SilenceServerService.py
@@ -293,15 +293,10 @@ class SilenceServerService(threading.Thread):
                 oldDataLen = len(data)
                 protocol = ""
                 byte = scooterSocket.recv(1)
+                if not byte:    # recv() returned b'': peer closed the connection (EOF)
+                    log.error(f"socket closed by peer (EOF) on receiver {receiverName}")
+                    return messages,1
                 data += byte
-                if len(data) == oldDataLen:     # If the bytearray has not incremented, the socket has crashed.
-                    if firstFrame:
-                        if len(data) > 0:
-                            _messageReceived(messages,data,protocol)
-                        return messages,0
-                    else:
-                        log.error("crashed socket 2")
-                        raise Exception("crashed socket 2")
 
                 if len(data) > 0 and int(data[-1]) == 36: #message starting with $
                     protocol = "Astra"
@@ -311,8 +306,11 @@ class SilenceServerService(threading.Thread):
                     _messageReceived(messages,data,"ACK")
                     continue
                 scooterSocket.settimeout(secondoTimeout)
-                while 1: 
+                while 1:
                     byte = scooterSocket.recv(1)
+                    if not byte:    # recv() returned b'': peer closed mid-frame (EOF)
+                        log.error(f"socket closed by peer (EOF) mid-frame on receiver {receiverName}")
+                        return messages,1
                     data += byte
                     if protocol == "Astra" and int(data[-1]) == 10 and int(data[-2]) == 13: #check for end of message started with $
                         _messageReceived(messages,data,protocol)
@@ -323,10 +321,14 @@ class SilenceServerService(threading.Thread):
 
                     oldDataLen = len(data)
 
-            except (socket.timeout, ConnectionError, TimeoutError) as e:
+            except socket.timeout:
                 if len(data) > 0:
                     _messageReceived(messages,data,protocol)
                 return messages,0
+
+            except OSError as e:    # ConnectionResetError, broken pipe, closed socket, ...
+                log.error(f"socket error on receiver {receiverName}: {e}")
+                return messages,1
 
             except Exception:
                 log.exception("_telegramReceiver exception")

--- a/services/SilenceServerService.py
+++ b/services/SilenceServerService.py
@@ -323,7 +323,24 @@ class SilenceServerService(threading.Thread):
 
             except socket.timeout:
                 if len(data) > 0:
-                    _messageReceived(messages,data,protocol)
+                    if protocol == "Astra" and len(data) >= 2 and int(data[-1]) == 10 and int(data[-2]) == 13:
+                        # Trame Astra complète arrivée pile au timeout
+                        _messageReceived(messages,data,protocol)
+                    elif receiverName != "A":
+                        # Côté Silence officiel (bridge) : comportement historique
+                        _messageReceived(messages,data,protocol)
+                    else:
+                        # Trame incomplète (coupure GSM / bus CAN en vrac) ou
+                        # octets hors protocole (scanners Internet sur le port
+                        # exposé) : on ne transmet RIEN au parseur ni à la base
+                        # — les trames tronquées produisaient des valeurs
+                        # aberrantes (odo à 980M via split() désaligné) et le
+                        # junk des scanners polluait le cache et la DB.
+                        log.warning(f"dropping invalid/incomplete telegram ({len(data)} bytes, protocol='{protocol or 'none'}') on receiver {receiverName}")
+                        if not messages:
+                            # Round sans AUCUN message valide : connexion
+                            # étrangère (scanner) -> on la ferme immédiatement.
+                            return messages,1
                 return messages,0
 
             except OSError as e:    # ConnectionResetError, broken pipe, closed socket, ...

--- a/tests/test_messageParser.py
+++ b/tests/test_messageParser.py
@@ -12,7 +12,9 @@ Real raw frames captured from a SEAT Mo 125 with the Astra AT402 v7.0.61.35
 telematics module are used where possible.
 """
 import pytest
+from unittest.mock import patch
 
+import helpers.messageParser as mp
 from helpers.messageParser import MessageParser
 
 
@@ -289,30 +291,74 @@ def test_normal_z_frame_not_touched_by_debundler(parser):
     assert parser.parameters["status"]["value"] == 4
 
 
-@pytest.mark.parametrize("sub_count", [3, 5, 7, 11])
-def test_bundled_frame_extracts_last_subframe(parser, sub_count):
-    # The debundler only kicks in for frames > 200 bytes. Real-world
-    # captures showed 2-11 sub-records per frame depending on how much
-    # $RCAN polling delayed the comm loop. Verify the math holds for
-    # representative sub_count values (2 gives 182 bytes, below the
-    # 200-byte threshold, so not debundled; 3 is the minimum that
-    # triggers the code path).
-    sub_size = 88
+def _bundle(sub_count, status=4, odo=None, sub_size=88):
+    """Build a bundled Z frame of `sub_count` records."""
     total_len = 4 + sub_count * sub_size + 2
-
     frame = bytearray(total_len)
     frame[0] = 0x5A
     frame[1] = (total_len >> 8) & 0xFF
     frame[2] = total_len & 0xFF
     frame[3] = sub_count
-
-    # All but the last sub have status=3 at offset (82 - 4) = 78.
-    # The last sub — which the debundler must extract — has status=4.
     for i in range(sub_count):
-        frame[4 + i * sub_size + 78] = 3 if i < sub_count - 1 else 4
+        base = 4 + i * sub_size
+        # status lives at byte 82 of a standalone frame -> offset 78 in a sub
+        frame[base + 78] = 3 if i < sub_count - 1 else status
+        if odo is not None:
+            # odo occupies bytes 83-86 of a standalone frame -> 79-82 in a sub
+            frame[base + 79: base + 83] = int(odo).to_bytes(4, "big")
+    return bytes(frame)
 
-    parser.parse_message_from_scooter_protocol_Z(bytes(frame))
+
+@pytest.mark.parametrize("sub_count", [3, 5, 7, 11])
+def test_bundled_frame_with_advancing_odo_keeps_motion(parser, sub_count):
+    # A bundle is a BACKLOG. While the odometer keeps advancing the scooter
+    # really is riding (the module is just late), so the motion state of the
+    # most recent record must be preserved.
+    parser.parse_message_from_scooter_protocol_Z(_bundle(sub_count, odo=16000))
+    parser.parse_message_from_scooter_protocol_Z(_bundle(sub_count, odo=16005))
     assert parser.parameters["status"]["value"] == 4
+
+
+@pytest.mark.parametrize("sub_count", [3, 11])
+def test_bundled_frame_with_frozen_odo_reports_stopped(parser, sub_count):
+    """Regression test for the 2026-07-26 phantom trips.
+
+    A parked scooter whose module re-sends its pending backlog for hours
+    (odometer frozen) must NOT be reported as riding: each replay used to
+    publish status=4/speed=82 and opened a trip in Home Assistant.
+    """
+    parser.parse_message_from_scooter_protocol_Z(_bundle(sub_count, odo=16681))
+    # same odometer, different payload -> not caught by the dedup, but the
+    # frozen odometer proves the readings are stale
+    parser.parse_message_from_scooter_protocol_Z(
+        _bundle(sub_count, status=3, odo=16681))
+    assert parser.parameters["status"]["value"] == 0
+    assert parser.parameters["speed"]["value"] == 0
+
+
+def test_bundled_frame_resent_is_ignored(parser):
+    """The module re-sends an unacknowledged bundle every few minutes."""
+    frame = _bundle(11, odo=16700)
+    parser.parse_message_from_scooter_protocol_Z(frame)
+    calls = []
+    with patch.object(mp.pub, "sendMessage", side_effect=lambda *a, **k: calls.append(k)):
+        parser.parse_message_from_scooter_protocol_Z(frame)
+        parser.parse_message_from_scooter_protocol_Z(frame)
+    assert calls == []
+
+
+def test_malformed_bundle_is_dropped(parser):
+    """Payload not a multiple of the sub-frame size: slicing it would emit
+    values straddling two records (odo=-1, soc=-23 seen in production)."""
+    frame = bytearray(_bundle(11, odo=16000))
+    frame = frame[:-5]                      # truncate: payload no longer 11x88
+    frame[1] = (len(frame) >> 8) & 0xFF
+    frame[2] = len(frame) & 0xFF
+    parser.parameters["odo"]["value"] = 16000.0
+    calls = []
+    with patch.object(mp.pub, "sendMessage", side_effect=lambda *a, **k: calls.append(k)):
+        parser.parse_message_from_scooter_protocol_Z(bytes(frame))
+    assert calls == []
 
 
 def test_bundled_frame_with_sub_count_one_is_not_debundled(parser):
@@ -382,7 +428,6 @@ def test_corrupt_odo_value_is_rejected(parser):
 def test_corrupt_odo_skips_publish(parser, monkeypatch):
     """Strong version: verify pub.sendMessage is NOT called on corrupt frame."""
     calls = []
-    import helpers.messageParser as mp
     monkeypatch.setattr(mp.pub, "sendMessage", lambda *a, **kw: calls.append((a, kw)))
 
     parser.scooter_off = False
@@ -411,7 +456,6 @@ def test_corrupt_odo_skips_publish(parser, monkeypatch):
 def test_valid_odo_does_publish(parser, monkeypatch):
     """Positive control: a frame with a plausible odo DOES publish."""
     calls = []
-    import helpers.messageParser as mp
     monkeypatch.setattr(mp.pub, "sendMessage", lambda *a, **kw: calls.append((a, kw)))
 
     parser.scooter_off = False
@@ -471,7 +515,6 @@ def test_get_scooter_off_status_getter(parser):
 
 def _capture_publishes(monkeypatch):
     calls = []
-    import helpers.messageParser as mp
     monkeypatch.setattr(mp.pub, "sendMessage", lambda *a, **kw: calls.append(kw))
     return calls
 

--- a/tests/test_messageParser.py
+++ b/tests/test_messageParser.py
@@ -373,16 +373,10 @@ def test_corrupt_odo_value_is_rejected(parser):
 
     parser.parse_message_from_scooter_protocol_Z(bytes(frame))
 
-    # The corrupt value should have been rejected by the >1_000_000 guard,
-    # meaning the publish was skipped. The internal parameters dict WILL
-    # contain the parsed value (the rejection happens just before publish),
-    # but the side-effect we care about in integration is: no MQTT publish.
-    # Here we assert the guard detected it by checking the value is
-    # either not the garbage (early return) or is flagged somehow.
-    # Since the guard does `return` before publish, the stored value IS
-    # the garbage — but the test proves the branch is reachable. A stronger
-    # test would need a mocked pub.sendMessage; see test below.
-    assert parser.parameters["odo"]["value"] > 1_000_000
+    # The corrupt value is rejected AND the cache is rolled back to the
+    # previous good value, so it can never leak through a later publish
+    # triggered by another frame type.
+    assert parser.parameters["odo"]["value"] == 15026.0
 
 
 def test_corrupt_odo_skips_publish(parser, monkeypatch):
@@ -469,3 +463,40 @@ def test_get_scooter_off_status_getter(parser):
     assert parser.get_scooter_off_status() is True
     parser.scooter_off = False
     assert parser.get_scooter_off_status() is False
+
+
+# ---------------------------------------------------------------------------
+# Ghost-values fix: nothing decoded => nothing republished
+# ---------------------------------------------------------------------------
+
+def _capture_publishes(monkeypatch):
+    calls = []
+    import helpers.messageParser as mp
+    monkeypatch.setattr(mp.pub, "sendMessage", lambda *a, **kw: calls.append(kw))
+    return calls
+
+
+def test_astra_er_frame_does_not_republish_cache(parser, monkeypatch):
+    """$RCAN,ER (CAN bus error) used to republish the ENTIRE stale cache and
+    refresh last-update — the source of 'ghost riding' telemetry while the
+    scooter sat parked with a faulty contactor."""
+    calls = _capture_publishes(monkeypatch)
+    parser.parse_message_from_scooter_protocol_astra(bytearray(b'$RCAN,ER\r\n'))
+    assert calls == []
+
+
+def test_astra_heartbeat_does_not_republish_cache(parser, monkeypatch):
+    calls = _capture_publishes(monkeypatch)
+    parser.parse_message_from_scooter_protocol_astra(
+        bytearray(b'$ASTRA;AT402;860000000000000;;7.0.61.35;Z;0\r\n'))
+    assert calls == []
+
+
+def test_astra_valid_cells_publish_only_decoded_keys(parser, monkeypatch):
+    calls = _capture_publishes(monkeypatch)
+    parser.parse_message_from_scooter_protocol_astra(
+        bytearray(b'$RCAN,185,08,5A,0E,5E,0E,64,0E,62,0E,OK\r\n'))
+    assert len(calls) == 1
+    published = calls[0]["scooter_status"]
+    assert set(published.keys()) == {"Cell1Voltage", "Cell2Voltage", "Cell3Voltage", "Cell4Voltage"}
+    assert published["Cell1Voltage"]["value"] == 0x0E5A

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,202 @@
+"""Unit tests for the audit fixes in services/.
+
+These tests validate:
+- CommandService logs no longer reference an undefined `imei` name
+  (NameError killed the scooter socket thread on every command from HA)
+- SilenceServerService._telegramReceiver treats recv() == b'' as EOF
+  instead of busy-looping at 100% CPU on a half-closed socket
+- MQTTService.start() no longer raises when the broker is unreachable
+  (paho connect_async + loop retries in the background instead)
+
+No network, no broker: sockets are faked, MQTT connects asynchronously.
+"""
+import socket
+import time
+
+import pytest
+
+from helpers.command import Command
+from services.CommandService import CommandService
+from services.SilenceServerService import SilenceServerService
+from services.MQTTService import MQTTService
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeSocket:
+    """Scripted socket: recv() returns/raises each item once, then b'' (EOF).
+
+    Fails the test if recv() is called an absurd number of times, which is
+    exactly what the pre-fix busy-loop did on a closed socket.
+    """
+
+    def __init__(self, script, max_recv_calls=500):
+        self.script = list(script)
+        self.recv_calls = 0
+        self.max_recv_calls = max_recv_calls
+
+    def settimeout(self, timeout):
+        pass
+
+    def recv(self, bufsize):
+        self.recv_calls += 1
+        if self.recv_calls > self.max_recv_calls:
+            raise AssertionError("busy-loop detected: recv() called too many times")
+        if self.script:
+            item = self.script.pop(0)
+            if isinstance(item, BaseException):
+                raise item
+            return item
+        return b''
+
+
+def _receive(fake_socket, first_frame=True):
+    # _telegramReceiver does not use `self`, call it unbound
+    return SilenceServerService._telegramReceiver(
+        None, fake_socket, 0.2, 0.2, "A", first_frame)
+
+
+COMMAND_CONFIG = {"command": "$POLL\r\n", "maxretry": 3, "timeout": 60}
+
+
+@pytest.fixture
+def command_service():
+    """CommandService with a minimal commands definition, no thread started."""
+    service = CommandService({}, "868000000000000")
+    service.commands_definition = {"POLL": COMMAND_CONFIG}
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: _telegramReceiver EOF handling (busy-loop on disconnect)
+# ---------------------------------------------------------------------------
+
+def test_telegram_receiver_eof_on_idle_socket_flags_crash():
+    # Peer closed the connection: recv() returns b'' immediately.
+    # Pre-fix this returned crashedFlag=0 and the caller spun forever.
+    messages, crashed = _receive(FakeSocket([]))
+    assert crashed == 1
+    assert messages == []
+
+
+def test_telegram_receiver_eof_mid_frame_does_not_busy_loop():
+    # FIN in the middle of an Astra frame: the inner recv() loop must
+    # detect b'' instead of re-checking the same bytes forever.
+    messages, crashed = _receive(FakeSocket([b'$', b'G', b'P']))
+    assert crashed == 1
+
+
+def test_telegram_receiver_eof_mid_frame_Z_protocol():
+    # Z frame announcing 10 bytes but connection dies after 4.
+    messages, crashed = _receive(FakeSocket([b'Z', b'\x00', b'\x0a', b'\x01']))
+    assert crashed == 1
+
+
+def test_telegram_receiver_connection_reset_flags_crash():
+    # RST mid-communication: must be a crash (1), not "no data" (0),
+    # otherwise the caller loops calling recv() on a dead socket.
+    messages, crashed = _receive(FakeSocket([ConnectionResetError(104, "reset")]))
+    assert crashed == 1
+
+
+def test_telegram_receiver_timeout_still_returns_no_crash():
+    # A plain timeout is the normal "nothing to read" case: flag stays 0.
+    messages, crashed = _receive(FakeSocket([socket.timeout()]))
+    assert crashed == 0
+    assert messages == []
+
+
+def test_telegram_receiver_complete_frame_then_eof():
+    # A full Astra frame is delivered, then EOF is reported on the next read.
+    frame = [b'$', b'A', b'\r', b'\n']
+    messages, crashed = _receive(FakeSocket(frame))
+    assert crashed == 1
+    assert len(messages) == 1
+    assert messages[0]["protocol"] == "Astra"
+    assert bytes(messages[0]["data"]) == b'$A\r\n'
+
+
+def test_telegram_receiver_partial_frame_on_timeout_still_delivered():
+    # Existing behaviour preserved: partial data on timeout is delivered.
+    messages, crashed = _receive(FakeSocket([b'$', b'A', socket.timeout()]))
+    assert crashed == 0
+    assert len(messages) == 1
+    assert bytes(messages[0]["data"]) == b'$A'
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: CommandService NameError on undefined `imei`
+# ---------------------------------------------------------------------------
+
+def test_command_received_queues_without_nameerror(command_service):
+    # Pre-fix the log f-string raised NameError, swallowed and re-raised
+    # as "Command not configurated" for every valid command.
+    command_service.command_received("POLL", "")
+    assert command_service.command_queue.qsize() == 1
+
+
+def test_command_executed_without_nameerror(command_service):
+    command_service.command_received("POLL", "")
+    command = command_service.get_next_command()
+    # Pre-fix this raised NameError in the scooter socket thread.
+    command_service.command_executed(command, "Ok".encode())
+    assert command_service.command_queue.qsize() == 0
+
+
+def test_command_failed_requeues_for_retry(command_service):
+    command_service.command_received("POLL", "")
+    command = command_service.get_next_command()
+    command_service.command_failed(command)
+    # maxretry=3, first failure: command must be back in the queue.
+    assert command_service.command_queue.qsize() == 1
+
+
+def test_command_failed_retry_limit_without_nameerror(command_service):
+    command_service.commands_definition = {
+        "POLL": {"command": "$POLL\r\n", "maxretry": 1, "timeout": 60}}
+    command_service.command_received("POLL", "")
+    command = command_service.get_next_command()
+    command_service.command_failed(command)
+    # maxretry=1: retry limit reached, not requeued.
+    assert command_service.command_queue.qsize() == 0
+
+
+def test_get_next_command_timeout_without_nameerror(command_service):
+    command_service.command_received("POLL", "")
+    expired = command_service.command_queue.queue[0]
+    expired.TSInserted = time.time() - 999
+    # Pre-fix the timeout log raised NameError.
+    command = command_service.get_next_command()
+    assert command is expired
+
+
+def test_cleanup_queue_timeout_without_nameerror(command_service):
+    command_service.command_received("POLL", "")
+    command_service.command_queue.queue[0].TSInserted = time.time() - 999
+    command_service.cleanup_queue()
+    assert command_service.command_queue.qsize() == 0
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: MQTTService must not die when the broker is unreachable
+# ---------------------------------------------------------------------------
+
+def test_mqtt_start_does_not_raise_with_broker_down():
+    configuration = {
+        "MQTTbroker": "127.0.0.1",
+        "MQTTport": 1,          # nothing listens here
+        "MQTTuser": "user",
+        "MQTTpass": "pass",
+        "TopicPrefix": "silence-scooter",
+    }
+    service = MQTTService(configuration, "868000000000000")
+    try:
+        # Pre-fix a synchronous connect() raised and the caller left the
+        # server as a zombie (TCP ACKs, no MQTT publish, no retry).
+        service.start()
+        assert service.client.on_connect_fail is not None
+        assert service.client.on_disconnect is not None
+    finally:
+        service.stop()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -52,10 +52,10 @@ class FakeSocket:
         return b''
 
 
-def _receive(fake_socket, first_frame=True):
+def _receive(fake_socket, first_frame=True, receiver="A"):
     # _telegramReceiver does not use `self`, call it unbound
     return SilenceServerService._telegramReceiver(
-        None, fake_socket, 0.2, 0.2, "A", first_frame)
+        None, fake_socket, 0.2, 0.2, receiver, first_frame)
 
 
 COMMAND_CONFIG = {"command": "$POLL\r\n", "maxretry": 3, "timeout": 60}
@@ -118,12 +118,42 @@ def test_telegram_receiver_complete_frame_then_eof():
     assert bytes(messages[0]["data"]) == b'$A\r\n'
 
 
-def test_telegram_receiver_partial_frame_on_timeout_still_delivered():
-    # Existing behaviour preserved: partial data on timeout is delivered.
+def test_telegram_receiver_partial_frame_from_scooter_is_dropped():
+    # NEW behaviour: a truncated Astra frame (GSM cut / flaky CAN bus) is
+    # never delivered to the parser — misaligned split() used to produce
+    # absurd values (odo=980M). A round with ONLY garbage closes the socket.
     messages, crashed = _receive(FakeSocket([b'$', b'A', socket.timeout()]))
+    assert crashed == 1
+    assert len(messages) == 0
+
+
+def test_telegram_receiver_partial_frame_from_silence_bridge_kept():
+    # Legacy behaviour preserved on the Silence-official side (bridge mode).
+    messages, crashed = _receive(FakeSocket([b'$', b'A', socket.timeout()]),
+                                 receiver="S")
     assert crashed == 0
     assert len(messages) == 1
     assert bytes(messages[0]["data"]) == b'$A'
+
+
+def test_telegram_receiver_scanner_junk_dropped_and_connection_closed():
+    # Internet scanners hitting the exposed port send HTTP bytes; they must
+    # never reach the parser/DB and the connection must be closed at once.
+    junk = [bytes([c]) for c in b'GET / HTTP/1.1'] + [socket.timeout()]
+    messages, crashed = _receive(FakeSocket(junk))
+    assert crashed == 1
+    assert len(messages) == 0
+
+
+def test_telegram_receiver_valid_frame_then_junk_keeps_connection():
+    # A round that contains at least one VALID frame keeps the connection
+    # alive even if trailing garbage is dropped (flaky scooter mid-ride).
+    seq = ([bytes([c]) for c in b'$RCAN,ER' + b'\r' + b'\n']
+           + [bytes([c]) for c in b'GARBAGE'] + [socket.timeout()])
+    messages, crashed = _receive(FakeSocket(seq))
+    assert crashed == 0
+    assert len(messages) == 1
+    assert bytes(messages[0]["data"]) == b'$RCAN,ER' + b'\r' + b'\n'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Hi Lorenzo, thanks for merging #15 and #18!

Here's a batch of fixes I collected over the summer, riding every day with a link that loves to bundle Z frames. Rebased on v2026.9.9, nothing changes in the MQTT topics or the config file.

- **Socket stuck at 100 % CPU**: `recv()` returning `b''` was not seen as a closed socket, so the loop spun forever. Now it ends the round like any crash.
- **MQTT client giving up at startup**: if the broker was down when the server started, it never published again. It now connects asynchronously and retries with backoff.
- **Ghost telemetry**: `$RCAN,ER`, heartbeats and junk bytes republished the whole cached state and refreshed `last-update`, so a parked scooter looked like it was riding for an hour. Only the keys actually decoded from a frame are published now.
- **Garbage telegrams**: truncated frames and HTTP bytes from Internet scanners were fed to the parser (hello odometer at 980 000 km). They are dropped before parsing.
- **Bundled Z frames**: the module re-sends pending bundles for hours. They are deduplicated by digest, malformed ones are dropped, and a bundle whose odometer has not moved for more than 5 minutes is reported as stopped. The 5 minutes matter: with a 1 km odometer, red lights produce identical values too.
- **`$STMS`** (on top of #18): publishes only what it decoded, and leaves `status` alone. Field 1 is only documented by a parked capture, and a SYNC from the app while riding would otherwise end the trip on the Home Assistant side. Happy to discuss this one if you see it differently.

87 tests pass, new ones cover each point above.
